### PR TITLE
Fixes for current active_model_serializers version with Rails

### DIFF
--- a/lib/active_model/version_serializer.rb
+++ b/lib/active_model/version_serializer.rb
@@ -6,9 +6,16 @@ require 'active_support/core_ext/hash/slice'
 module ActiveModel
   class VersionSerializer
 
-    # make sure we move serialization to the version 
-    [:as_json, :to_json, :serializable_hash].each do |method|
-      undef_method method if instance_methods.include?(method)
+    def as_json(*args)
+      @vinstance.as_json(*args)
+    end
+
+    def to_json(*args)
+      @vinstance.to_json(*args)
+    end
+
+    def serializable_hash(*args)
+      @vinstance.serializable_hash(*args)
     end
 
     class_attribute :_versions, :_default, :_root, :_name

--- a/spec/scenerio/user_serialization_spec.rb
+++ b/spec/scenerio/user_serialization_spec.rb
@@ -84,6 +84,6 @@ describe "UserSerialization" do
     end
 
     subject{user_serializer.as_json}
-    it{should eq({user: user_attributes.merge(turns: [1,2,3]), turns: turn_attributes})}
+    it{should eq({user: user_attributes.merge(turn_ids: [1,2,3]), turns: turn_attributes})}
   end
 end


### PR DESCRIPTION
Hey there:

You might be able to shed some light on why, but before I explicitly defined `#as_json`, `#to_json`, and `#serializable_hash` as delegates to the versioned instance, they were using the default implementations and yielding a hash representation which looked like this:

```
{ options: [ ... ], object: { ... }
```

This was when using the gem under Rails 3.2 with the latest version of active_model_serializers (0.8.1).

Anyway, if you think this is worth pulling, go for it :)
